### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol server that builds Android project that enables seamless workflow working with Android projects in Visual Studio Code using extensions like Cline or Roo Code.
 
+<a href="https://glama.ai/mcp/servers/@ShenghaiWang/androidbuild">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ShenghaiWang/androidbuild/badge" alt="Android Project Server MCP server" />
+</a>
+
 ### Available Tools
 
 - `build` - Build Android project


### PR DESCRIPTION
This PR adds a badge for the [Android Project MCP Server](https://glama.ai/mcp/servers/@ShenghaiWang/androidbuild) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ShenghaiWang/androidbuild">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ShenghaiWang/androidbuild/badge" alt="Android Project Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.